### PR TITLE
Parser Rewrite

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,74 +1,50 @@
 module.exports = grammar({
   	name: 'norg',
 
-	conflicts: $ => [
-		[$.carryover_tag],
-	],
-
-	/* externals: $ => [
+	externals: $ => [
     	$.bold
-  	], */
+  	],
 
   	rules: {
-    	document: $ => repeat(choice(prec(2, $._detached_modifiers), $._soft_paragraph_break, $.paragraph)),
-
-		quote: $ => seq(optional($.leading_whitespace), />\s+/, choice($.paragraph_segment, prec(1, seq($.words, $._soft_paragraph_break, $.quote)))),
-
-		heading1_prefix: $ => /\*\s+/, 
-		heading2_prefix: $ => /\*\*\s+/, 
-		heading3_prefix: $ => /\*\*\*\s+/, 
-		heading4_prefix: $ => /\*\*\*\*\s+/, 
-
-		heading1: $ => seq(optional($.leading_whitespace), $.heading1_prefix, $.paragraph_segment),
-		heading2: $ => seq(optional($.leading_whitespace), $.heading2_prefix, $.paragraph_segment),
-		heading3: $ => seq(optional($.leading_whitespace), $.heading3_prefix, $.paragraph_segment),
-		heading4: $ => seq(optional($.leading_whitespace), $.heading4_prefix, $.paragraph_segment),
-
-		unordered_list_prefix: $ => token.immediate(/\-\s+/),
-		unordered_list: $ => seq(optional($.leading_whitespace), $.unordered_list_prefix, $.paragraph_segment),
-
-		unordered_link_list_prefix: $ => token.immediate(/\->\s+/),
-		unordered_link_list: $ => seq(optional($.leading_whitespace), $.unordered_link_list_prefix, $.paragraph_segment),
-
-		marker: $ => seq(optional($.leading_whitespace), /\|\s+/, $.paragraph_segment),
-
-		// A bit of a mess, but required for precise syntax highlighting
-		todo_item_prefix: $ => token.immediate('['),
-		todo_item_suffix: $ => token.immediate(/\]\s+/),
-		todo_item_done_mark: $ => token.immediate(/[\t ]*x[\t ]*/),
-		todo_item_pending_mark: $ => token.immediate(/[\t ]*\*[\t ]*/),
-		todo_item_undone_mark: $ => token.immediate(/\s+/), 
-
-		todo_item_done: $ => seq(optional($.leading_whitespace), $.unordered_list_prefix, $.todo_item_prefix, $.todo_item_done_mark, $.todo_item_suffix, $.paragraph_segment),
-		todo_item_pending: $ => seq(optional($.leading_whitespace), $.unordered_list_prefix, $.todo_item_prefix, $.todo_item_pending_mark, $.todo_item_suffix, $.paragraph_segment),
-		todo_item_undone: $ => seq(optional($.leading_whitespace), $.unordered_list_prefix, $.todo_item_prefix, $.todo_item_undone_mark, $.todo_item_suffix, $.paragraph_segment),
-
-		tag: $ => seq(optional($.leading_whitespace), token.immediate('@'), $.tag_name, repeat(seq(token.immediate('.'), $.tag_name)), choice(seq(repeat1(token(/[\t ]+/)), choice(seq($.tag_parameters, repeat(seq(token.immediate(/[\t ]+/), $.tag_parameters))), $._soft_paragraph_break)), $._soft_paragraph_break), $.tag_content, $.tag_end),
-		tag_content: $ => repeat1(choice(/[^\n]+/, $._soft_paragraph_break)),
-		tag_name: $ => repeat1(/[a-z_]/),
-		tag_parameters: $ => token.immediate(/[^\n]+/),
-		tag_end: $ => token('@end'),
-
-		carryover_tag: $ => seq(optional($.leading_whitespace), token.immediate('$'), $.tag_name, repeat(seq(token.immediate('.'), $.tag_name)), choice(seq(repeat1(token(/[\t ]+/)), choice(seq($.tag_parameters, repeat(seq(token.immediate(/[\t ]+/), $.tag_parameters))), $._soft_paragraph_break)), $._soft_paragraph_break), repeat($._soft_paragraph_break), choice(repeat1($._detached_modifiers), $.paragraph)),
-
-		drawer: $ => seq(optional($.leading_whitespace), token(/\|{2}[\t ]+/), field("drawer_name", $.paragraph_segment), optional($.drawer_content), token('||')),
-		drawer_content: $ => repeat1(choice(/[^\\]/, $.escape_sequence)),
-
-		paragraph: $ => prec.left(1, seq(repeat1(prec(1, choice($.paragraph_segment, $.escape_sequence))), optional(choice($._soft_paragraph_break, $._eof)))),
-
-		_eof: $ => token.immediate('\0'),
-		_soft_paragraph_break: $ => token.immediate('\n'),
-		leading_whitespace: $ => repeat1(token.immediate(/[\t\v ]/)),
-
-		// Unused, I could not get them to properly get detected with the rules imposed by the Neorg specification
-		// If you know how to do this then please consider submitting a PR
-		_attached_modifiers: $ => choice(token.immediate('*'), token.immediate('_'), token.immediate('`'), token.immediate('|'), token.immediate('^'), token.immediate('$')),
-
-		escape_sequence: $ => seq(token.immediate('\\'), token.immediate(/./)),
-		words: $ => seq(choice(/[^\s]/, $.leading_whitespace), repeat(/[^\n]/)),
-		paragraph_segment: $ => choice(seq($.words, $.trailing_modifier, token.immediate('\n'), $.paragraph_segment), seq($.words, choice($._soft_paragraph_break, $._eof))),
-		trailing_modifier: $ => token.immediate('~'),
-		_detached_modifiers: $ => choice($.todo_item_done, $.todo_item_pending, $.todo_item_undone, $.heading1, $.heading2, $.heading3, $.heading4, $.quote, $.marker, $.tag, $.carryover_tag, $.drawer, $.unordered_list, $.unordered_link_list),
-
+    	/*
+        "document",
+		"quote",
+		"heading1_prefix",
+		"heading2_prefix",
+		"heading3_prefix",
+		"heading4_prefix",
+		"heading1",
+		"heading2",
+		"heading3",
+		"heading4",
+		"unordered_list_prefix",
+		"unordered_list",
+		"unordered_link_list_prefix",
+		"unordered_link_list",
+		"marker",
+		"todo_item_prefix",
+		"todo_item_suffix",
+		"todo_item_done_mark",
+		"todo_item_pending_mark",
+		"todo_item_undone_mark",
+		"todo_item_done",
+		"todo_item_pending",
+		"todo_item_undone",
+		"tag",
+		"tag_content",
+		"tag_name",
+		"tag_parameters",
+		"tag_end",
+		"carryover_tag",
+		"drawer",
+		"drawer_content",
+		"paragraph",
+		"_eof",
+		"_soft_paragraph_break",
+		"leading_whitespace",
+		"escape_sequence",
+		"words",
+		"paragraph_segment",
+		"_detached_modifiers", */
   	}
 });

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,0 +1,102 @@
+#include "tree_sitter/parser.h"
+#include <locale>
+#include <iostream>
+#include <regex>
+
+enum TokenType
+{
+	BOLD
+};
+
+class Scanner
+{
+public:
+
+	void skip(TSLexer* lexer)
+	{
+		return lexer->advance(lexer, true);
+	}
+
+	void advance(TSLexer* lexer)
+	{
+		return lexer->advance(lexer, false);
+	}
+
+	bool scan(TSLexer* lexer, const bool* valid_symbols)
+	{
+		if (valid_symbols[BOLD])
+		{
+			if (std::iswpunct(lexer->lookahead) || std::iswspace(lexer->lookahead))
+			{
+				skip(lexer);
+				if (lexer->lookahead == '*')
+				{
+					skip(lexer);
+					if (!std::iswspace(lexer->lookahead) && lexer->lookahead != '*')
+					{
+						advance(lexer);
+						if (lexer->lookahead == '*')
+							return false;
+
+						while (lexer->lookahead && lexer->lookahead != '\n')
+						{
+							advance(lexer);
+
+							if (lexer->lookahead == '\\')
+							{
+								advance(lexer);
+								advance(lexer);
+								continue;
+							}
+
+							else if (lexer->lookahead == '*')
+							{
+								skip(lexer);
+								if (std::iswspace(lexer->lookahead) || std::iswpunct(lexer->lookahead))
+								{
+									lexer->result_symbol = BOLD;
+									lexer->mark_end(lexer);
+									return true;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		/* if (valid_symbols[PARAGRAPH])
+		{
+			lexer->result_symbol = PARAGRAPH;
+			return true;
+		} */
+		return false;
+	}
+private:
+	std::string m_State;
+};
+
+extern "C"
+{
+	void* tree_sitter_norg_external_scanner_create()
+	{
+		return new Scanner();
+	}
+
+	void tree_sitter_norg_external_scanner_destroy(void* payload)
+	{
+  		delete (Scanner*)payload;
+	}
+
+	bool tree_sitter_norg_external_scanner_scan(void* payload, TSLexer* lexer, const bool* valid_symbols)
+	{
+  		return static_cast<Scanner*>(payload)->scan(lexer, valid_symbols);
+	}
+
+	unsigned tree_sitter_norg_external_scanner_serialize(void* payload, char* buffer)
+	{
+  		return 0;
+	}
+
+	void tree_sitter_norg_external_scanner_deserialize(void* payload, const char* buffer, unsigned length) {}
+}


### PR DESCRIPTION
Today's the day. The decision has been made. The parser - although cool, simply wasn't enough for a format like Neorg. Neorg needs a decent chunk of custom lexing. I will try and implement as many things as I can via regex rules and will only use the lexer as a last resort (aka the good way of doing things).

Things we need:
- If a token cannot be detected then mark it as a paragraph
- Detecting `*bold*`, `/italic/`, `_underline_`, `[these](links)` and all the other modifiers present in the specification.
- Properly identifying escape sequences
- Distinguishing attached vs detached modifiers
- Making sure the parser doesn't crash every 3.5ms :P
- The ability for the parser to create a true structured syntax tree. For example, the current parser generates trees similar to this:
  ```
  heading1
    leading_whitespace
    heading1_prefix
    paragraph_segment
  paragraph
    paragraph_segment
        words
  ```
  Since the paragraph is underneath the heading you would logically want it to look like so:
  ```
    heading1
      etc.
      paragraph
          paragraph_segment
             words
  ```

Excited to start this new endeavor. I'll start proper work on the parser tomorrow. If you have any experience with TreeSitter and wanna hop along for the ride and help out then please do! :)