### PR TITLE
Minor fixes

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -519,7 +519,7 @@ private:
             }
             // A [ is a special symbol - it can both mean a todo item and a link
             // Halt the parsing of the paragraph segment if such a thing is encountered
-            else if (m_TagStack.size() == 0 && std::iswspace(m_Current) && lexer->lookahead == '[')
+            else if (m_TagStack.size() == 0 && (std::iswspace(m_Current) || std::ispunct(m_Current)) && lexer->lookahead == '[')
             {
                 m_LastToken = PARAGRAPH_SEGMENT;
                 lexer->result_symbol = PARAGRAPH_SEGMENT;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -247,13 +247,6 @@ public:
                             }
                         }
                     }
-
-                    while (lexer->lookahead && lexer->lookahead != '.' && !std::iswspace(lexer->lookahead))
-                        advance(lexer);
-
-                    lexer->result_symbol = m_LastToken = RANGED_TAG_NAME;
-                    lexer->mark_end(lexer);
-                    return true;
                 }
 
                 lexer->result_symbol = m_LastToken = RANGED_TAG;


### PR DESCRIPTION
This includes two minor fixes:

1. Links should allow punctuation in front of the and not require a whitespace (this requirement only holds for TODO syntax).

2. Correct parsing of ranged tag names starting with `e`. See screenshot below (although this second commit is kind of odd, I admit that)...

![screenshot_1631047309](https://user-images.githubusercontent.com/21973473/132408576-89a4d888-5ade-4340-81a7-be2db8debab7.png)

Note, that the ranged tag name `endeavour` is also handled properly even though it starts with `end`.